### PR TITLE
remove setZoom from Clear map

### DIFF
--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -128,7 +128,7 @@ class Map {
       }
     });
 
-    this.setZoom();
+    //this.setZoom();
     if (this.hasPersonas) {
       const activePersonas = document.getElementsByClassName(
         PERSONA_ACTIVE_CLASS


### PR DESCRIPTION
# Description

setZoom has been removed when clicking on Clear Map

# How to test

Zoom in and click on Clear Map. The map should clear the layers but the view/zoom shouldn't change

