### PR TITLE
Task/projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ The options for the data file are as follows:
 | `showGeoServerMetadata` | Boolean | optional | If `true` the code will try to read the metadata (from `metadata.public_metadata`) via geoserver and add it to the infoBox that appears when you click on "About the data of this map" on desktop or on the information icon on mobile. This is a view on Earthlight metadata. This includes the name of the layer, the abstract, source and last update date of each layer of the map. |
 | `about` | String | optional | If `showGeoServerMetadata` is set to false, `about` can be used to populate the text in the infoBox described above. |
 | `aboutTitle` | String | optional | `aboutTitle` can be used to populate the title of the infoBox described above (e.g: About the data/About the map) |
-| `baseStyle` | String | optional | style to use for the base map. Possible values:<br>`OSlight`: OS Light style. <br>`OSoutdoor`: OS Outdoor style. <br>`OSroad`: OS Road style.<br>`streets`: Mapbox street is the closest style to Google. Amended to remove commercial points of interest at small scale.<br>`light`: Mapbox light grey style.<br>`dark`: Mapbox black style<br>any other value, empty or omitted: the classical beige style we used for the initial leaflet maps |
-| `zoomToMasterMap` | Boolean | optional | If `true` the top 3 levels of zoom show Ordnance Survey masterMap outdoor style. |
+| `baseStyle` | String | optional | style to use for the base map. Possible values:<br>`OSlight`: OS Light style. <br>`OSoutdoor`: OS Outdoor style. <br>`OSroad`: OS Road style.<br>We removed the MapBox option in Sept 2021 and are now only using British National Grid as the map CRS.|
+| `zoomToMasterMap` | Boolean | optional | This is currently not is use and will be reimplemeted soon.|
 | `zoomToMasterMapBW` | Boolean | optional | If `true` the top 3 levels of zoom show Ordnance Survey masterMap black and white style. |
 | `showLocateButton` | Boolean | optional | If `true` a button with geolocation function will be added to the map. |
 | `showFullScreenButton` | Boolean | optional | If `true` a button with fullscreen function will be added to the map. |

--- a/data/covid-support/map-definition.json
+++ b/data/covid-support/map-definition.json
@@ -7,7 +7,7 @@
   "showLegend": true,
   "showFirstLayerOnLoad": true,
   "downloadLink": "<b><a href='https://map.hackney.gov.uk/geoserver/ows?service=WFS&version=2.0.0&request=GetFeature&typenames=statmap:covid_assistance_all&propertyName=organisation_name,categories,about_us,address&outputformat=csv'>Download a snapshot of the data</a></b>",
-  "baseStyle": "streets",
+  "baseStyle": "OSroad",
   "list":{
     "sectionHeader": "List of all organisations",
     "showIcons": true

--- a/data/local-plan/map-definition.json
+++ b/data/local-plan/map-definition.json
@@ -8,7 +8,7 @@
   "showFullScreenButton": true,
   "showLegend": true,
   "showGeoServerMetadata": false,
-  "baseStyle": "light",
+  "baseStyle": "OSlight",
   "personas": [
     {
       "id": "employment",

--- a/data/locally-listed-buildings-with-search/map-definition.json
+++ b/data/locally-listed-buildings-with-search/map-definition.json
@@ -6,12 +6,11 @@
    "layers": [
     {
       "title": "Locally listed buildings",
-      "geoserverLayerName": "planning:locally_listed_building_point",
+      "geoserverLayerName": "planning:locally_listed_building",
       "pointStyle": {
         "markerType": "AwesomeMarker",
         "icon": "fa-warehouse",
-        "markerColor": "cadetblue",
-        "cluster": true
+        "markerColor": "cadetblue"
       },
       "popup": {
         "fields": [

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "leaflet-search": "^2.9.8",
     "leaflet.awesome-markers": "^2.0.5",
     "leaflet.markercluster": "^1.4.1",
+    "proj4leaflet": "^1.0.2",
     "pubsub-js": "^1.8.0",
     "whatwg-fetch": "^3.0.0"
   },

--- a/src/js/map/consts.js
+++ b/src/js/map/consts.js
@@ -2,16 +2,16 @@ import MAPBOX_ACCESS_KEY from "../helpers/mapbox";
 import OS_RASTER_API_KEY from "../helpers/osdata";
 
 
-const MAX_ZOOM = 19;
-const MIN_ZOOM = 12;
+const MAX_ZOOM = 12;
+const MIN_ZOOM = 4;
 const CENTER_DESKTOP_LEGEND_FULLSCREEN = [51.534, -0.083];
 const CENTER_DESKTOP_LEGEND = [51.548, -0.083];
 const CENTER_DESKTOP_NO_LEGEND_FULLSCREEN = [51.534, -0.06];
 const CENTER_DESKTOP_NO_LEGEND = [51.548, -0.06];
 const CENTER_MOBILE_FULLSCREEN = [51.538, -0.059928];
 const CENTER_MOBILE = [51.549, -0.059928];
-const DEFAULT_ZOOM_DESKTOP = 13;
-const DEFAULT_ZOOM_MOBILE = 11;
+const DEFAULT_ZOOM_DESKTOP = 6;
+const DEFAULT_ZOOM_MOBILE = 5;
 // const MAP_BOUNDS = [
 //   [51.491112, -0.275464],
 //   [51.607351, 0.096129]
@@ -45,7 +45,7 @@ const TILE_LAYER_OPTIONS_OS = {
   opacity: 1,
   attribution:
     'Map data &copy; Crown copyright and database rights 2021 <a href="https://www.ordnancesurvey.co.uk/">Ordnance Survey</a> 100019635.' ,
-  maxZoom: 19,
+  maxZoom: 12,
   accessToken: OS_RASTER_API_KEY
 };
 

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -358,7 +358,7 @@ class DataLayers {
         //create clusters
         const markers = L.markerClusterGroup({
           maxClusterRadius: 60,
-          disableClusteringAtZoom: 18,
+          disableClusteringAtZoom: 12,
           spiderfyOnMaxZoom: false,
           showCoverageOnHover: false
         });

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -48,8 +48,7 @@ class Map {
     this.mapConfig = null;
     this.hackneyMask = null;
     this.hackneyBoundary = null;
-    this.masterMapLayer = null;
-    this.OSMBase = null;
+    this.mapBase = null;
     this.hasPersonas = false;
     this.errorOutsideHackney = GENERIC_OUTSIDE_HACKNEY_ERROR;
     this.errorNoLocation = GENERIC_GEOLOCATION_ERROR;
@@ -132,11 +131,9 @@ class Map {
   clear() {
     this.map.eachLayer(layer => {
       if (
-        layer !== this.OSMBase &&
+        layer !== this.mapBase &&
         layer !== this.hackneyMask &&
-        layer !== this.hackneyBoundary &&
-        layer !== this.masterMapLayer &&
-        layer !== this.masterMapLayerBW
+        layer !== this.hackneyBoundary
       ) {
         this.map.removeLayer(layer);
       }
@@ -204,14 +201,6 @@ class Map {
 
     this.addBaseLayer();
 
-    if (this.mapConfig.zoomToMasterMap) {
-      this.addMasterMapLayer();
-    }
-
-    if (this.mapConfig.zoomToMasterMapBW) {
-      this.addMasterMapLayerBW();
-    }
-
     if (this.mapConfig.showHackneyMask) {
       this.addHackneyMaskLayer();
     }
@@ -247,76 +236,31 @@ class Map {
 
   }
 
-  addMasterMapLayer() {
-    this.masterMapLayer = L.tileLayer.wms(HACKNEY_GEOSERVER_WMS, {
-      layers: "osmm:OSMM_outdoor_leaflet",
-      format: "image/png",
-      tiled: true,
-      transparent: true,
-      minZoom: 18,
-      maxZoom: 20,
-      opacity: 1
-    });
-    this.map.addLayer(this.masterMapLayer);
-  }
-
-
-  addMasterMapLayerBW() {
-    this.masterMapLayerBW = L.tileLayer.wms(HACKNEY_GEOSERVER_WMS, {
-      layers: "osmm:OSMM_blackwhite_leaflet",
-      format: "image/png",
-      tiled: true,
-      transparent: true,
-      minZoom: 18,
-      maxZoom: 20,
-      opacity: 1
-    });
-    this.map.addLayer(this.masterMapLayerBW);
-  }
 
   addBaseLayer() {
     if (this.mapConfig.baseStyle == "OSoutdoor") {
-      this.OSMBase = L.tileLayer(
+      this.mapBase = L.tileLayer(
         `https://api.os.uk/maps/raster/v1/zxy/Outdoor_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
     } else if (this.mapConfig.baseStyle == "OSlight") {
-      this.OSMBase = L.tileLayer(
+      this.mapBase = L.tileLayer(
         `https://api.os.uk/maps/raster/v1/zxy/Light_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
     } else if (this.mapConfig.baseStyle == "OSroad") {
-      this.OSMBase = L.tileLayer(
+      this.mapBase = L.tileLayer(
         `https://api.os.uk/maps/raster/v1/zxy/Road_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
     }
-    // } else if (this.mapConfig.baseStyle == "light") {
-    //   this.OSMBase = L.tileLayer(
-    //     `https://api.mapbox.com/styles/v1/hackneygis/cj8vdhus57vpi2spshe68ho4m/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_KEY}`,
-    //     TILE_LAYER_OPTIONS_MAPBOX
-    //   );
-    // } else if (this.mapConfig.baseStyle == "dark") {
-    //   this.OSMBase = L.tileLayer(
-    //     MAPBOX_TILES_URL,
-    //     Object.assign(TILE_LAYER_OPTIONS_MAPBOX, { id: "mapbox.dark" })
-    //   );
-    // } else if (this.mapConfig.baseStyle == "streets") {
-    //   this.OSMBase = L.tileLayer(
-    //     `https://api.mapbox.com/styles/v1/hackneygis/ck7ounc2t0cg41imjb3j53dp8/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_KEY}`,
-    //     TILE_LAYER_OPTIONS_MAPBOX
-    //   );
-    // }else {
-    //   this.OSMBase = L.tileLayer(
-    //     MAPBOX_TILES_URL,
-    //     Object.assign(TILE_LAYER_OPTIONS_MAPBOX, { id: "mapbox.streets" })
-    //   );
+    
+    //limit zoom for OSM if mastermap is shown 
+    //TODO: set a max zoom in zoomToMasterMap is false
+    // if (this.mapConfig.zoomToMasterMap || this.mapConfig.zoomToMasterMapBW){
+    //   this.mapBase.maxZoom = 17;
     // }
-    //limit zoom for OSM if mastermap is shown
-    if (this.mapConfig.zoomToMasterMap || this.mapConfig.zoomToMasterMapBW){
-      this.OSMBase.maxZoom = 17;
-    }
-    this.map.addLayer(this.OSMBase);
+    this.map.addLayer(this.mapBase);
   }
 
   addHackneyMaskLayer() {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -1,5 +1,6 @@
 
 import L from "leaflet";
+import "proj4leaflet";
 import {
   isMobile as isMobileFn,
   mobileDesktopSwitch
@@ -160,21 +161,34 @@ class Map {
     this.isFullScreen = paths[paths.length - 1] === "fullscreen" || paths[paths.length - 1] === "fullscreen.html";
   }
 
+      // Transform coordinates.
+  // transformCoords(arr) {
+  //   return proj4('EPSG:27700', 'EPSG:4326', arr).reverse();
+  // }
 
   
   createMap() {
+
+    // Setup the EPSG:27700 (British National Grid) projection.
+    var crs = new L.Proj.CRS('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs', {
+      resolutions: [896.0, 448.0, 224.0, 112.0, 56.0, 28.0, 14.0, 7.0, 3.5, 1.75, 0.875, 0.4375, 0.21875, 0.109375],
+      origin: [ -238375.0, 1376256.0 ]
+    });
 
     //gesture handler
     L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling);
 
     this.map = L.map("map", {
+      crs: crs,
       zoomControl: false,
       maxZoom: MAX_ZOOM,
       minZoom: MIN_ZOOM,
       center: this.centerDesktop,
-      //zoom: DEFAULT_ZOOM_DESKTOP,
+      zoom: DEFAULT_ZOOM_DESKTOP,
       zoom: this.zoom,
       gestureHandling: L.Browser.mobile
+      // center: this.transformCoords([ 337297, 503695 ]),
+      // zoom: 7
     });
 
     this.map.setMaxBounds(MAP_BOUNDS);
@@ -276,7 +290,7 @@ class Map {
       );
     } else if (this.mapConfig.baseStyle == "OSoutdoor") {
       this.OSMBase = L.tileLayer(
-        `https://api.os.uk/maps/raster/v1/zxy/Outdoor_3857/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
+        `https://api.os.uk/maps/raster/v1/zxy/Outdoor_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
     } else if (this.mapConfig.baseStyle == "OSlight") {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -161,14 +161,8 @@ class Map {
     this.isFullScreen = paths[paths.length - 1] === "fullscreen" || paths[paths.length - 1] === "fullscreen.html";
   }
 
-      // Transform coordinates.
-  // transformCoords(arr) {
-  //   return proj4('EPSG:27700', 'EPSG:4326', arr).reverse();
-  // }
-
   
   createMap() {
-
     // Setup the EPSG:27700 (British National Grid) projection.
     var crs = new L.Proj.CRS('EPSG:27700', '+proj=tmerc +lat_0=49 +lon_0=-2 +k=0.9996012717 +x_0=400000 +y_0=-100000 +ellps=airy +towgs84=446.448,-125.157,542.06,0.15,0.247,0.842,-20.489 +units=m +no_defs', {
       resolutions: [896.0, 448.0, 224.0, 112.0, 56.0, 28.0, 14.0, 7.0, 3.5, 1.75, 0.875, 0.4375, 0.21875, 0.109375],
@@ -187,8 +181,6 @@ class Map {
       zoom: DEFAULT_ZOOM_DESKTOP,
       zoom: this.zoom,
       gestureHandling: L.Browser.mobile
-      // center: this.transformCoords([ 337297, 503695 ]),
-      // zoom: 7
     });
 
     this.map.setMaxBounds(MAP_BOUNDS);
@@ -283,42 +275,43 @@ class Map {
   }
 
   addBaseLayer() {
-    if (this.mapConfig.baseStyle == "streets") {
-      this.OSMBase = L.tileLayer(
-        `https://api.mapbox.com/styles/v1/hackneygis/ck7ounc2t0cg41imjb3j53dp8/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_KEY}`,
-        TILE_LAYER_OPTIONS_MAPBOX
-      );
-    } else if (this.mapConfig.baseStyle == "OSoutdoor") {
+    if (this.mapConfig.baseStyle == "OSoutdoor") {
       this.OSMBase = L.tileLayer(
         `https://api.os.uk/maps/raster/v1/zxy/Outdoor_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
     } else if (this.mapConfig.baseStyle == "OSlight") {
       this.OSMBase = L.tileLayer(
-        `https://api.os.uk/maps/raster/v1/zxy/Light_3857/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
+        `https://api.os.uk/maps/raster/v1/zxy/Light_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
     } else if (this.mapConfig.baseStyle == "OSroad") {
       this.OSMBase = L.tileLayer(
-        `https://api.os.uk/maps/raster/v1/zxy/Road_3857/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
+        `https://api.os.uk/maps/raster/v1/zxy/Road_27700/{z}/{x}/{y}.png?key=${OS_RASTER_API_KEY}`,
         TILE_LAYER_OPTIONS_OS
       );
-    } else if (this.mapConfig.baseStyle == "light") {
-      this.OSMBase = L.tileLayer(
-        `https://api.mapbox.com/styles/v1/hackneygis/cj8vdhus57vpi2spshe68ho4m/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_KEY}`,
-        TILE_LAYER_OPTIONS_MAPBOX
-      );
-    } else if (this.mapConfig.baseStyle == "dark") {
-      this.OSMBase = L.tileLayer(
-        MAPBOX_TILES_URL,
-        Object.assign(TILE_LAYER_OPTIONS_MAPBOX, { id: "mapbox.dark" })
-      );
-    } else {
-      this.OSMBase = L.tileLayer(
-        MAPBOX_TILES_URL,
-        Object.assign(TILE_LAYER_OPTIONS_MAPBOX, { id: "mapbox.streets" })
-      );
     }
+    // } else if (this.mapConfig.baseStyle == "light") {
+    //   this.OSMBase = L.tileLayer(
+    //     `https://api.mapbox.com/styles/v1/hackneygis/cj8vdhus57vpi2spshe68ho4m/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_KEY}`,
+    //     TILE_LAYER_OPTIONS_MAPBOX
+    //   );
+    // } else if (this.mapConfig.baseStyle == "dark") {
+    //   this.OSMBase = L.tileLayer(
+    //     MAPBOX_TILES_URL,
+    //     Object.assign(TILE_LAYER_OPTIONS_MAPBOX, { id: "mapbox.dark" })
+    //   );
+    // } else if (this.mapConfig.baseStyle == "streets") {
+    //   this.OSMBase = L.tileLayer(
+    //     `https://api.mapbox.com/styles/v1/hackneygis/ck7ounc2t0cg41imjb3j53dp8/tiles/256/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_KEY}`,
+    //     TILE_LAYER_OPTIONS_MAPBOX
+    //   );
+    // }else {
+    //   this.OSMBase = L.tileLayer(
+    //     MAPBOX_TILES_URL,
+    //     Object.assign(TILE_LAYER_OPTIONS_MAPBOX, { id: "mapbox.streets" })
+    //   );
+    // }
     //limit zoom for OSM if mastermap is shown
     if (this.mapConfig.zoomToMasterMap || this.mapConfig.zoomToMasterMapBW){
       this.OSMBase.maxZoom = 17;


### PR DESCRIPTION
# Description

Use 27700 as the crs of the map. That solves the shift issue when overlaying WFS layers on top of OS Maps API. Some related changes about the use of Mapbox and the old ZoomToMatserMap behaviour.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

