### PR TITLE
Feature/add blpu boundary uprn in url

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "leaflet-control-custom": "^1.0.0",
     "leaflet-control-window": "^1.0.0",
     "leaflet-easybutton": "^2.4.0",
+    "leaflet-geometryutil": "^0.10.0",
     "leaflet-gesture-handling": "^1.1.8",
     "leaflet-panel-layers": "^1.2.6",
     "leaflet-search": "^2.9.8",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "leaflet-control-custom": "^1.0.0",
     "leaflet-control-window": "^1.0.0",
     "leaflet-easybutton": "^2.4.0",
-    "leaflet-geometryutil": "^0.10.0",
     "leaflet-gesture-handling": "^1.1.8",
     "leaflet-panel-layers": "^1.2.6",
     "leaflet-search": "^2.9.8",

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -283,6 +283,11 @@ class DataLayers {
 
     this.loadedLayerCount++;
 
+    //only happens once, after the last layer has loaded - put the BLPUpolygon layer on top if it exists
+    if (this.mapClass.blpuPolygon && this.loadedLayerCount == this.layerCount) {
+      this.mapClass.blpuPolygon.bringToFront();
+    }
+
     //only happens once, after the last layer has loaded - create filters above the map
     if (this.mapConfig.filters && this.loadedLayerCount == this.layerCount) {
       this.filters = new Filters(this.mapClass, this.layersData);

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -133,12 +133,19 @@ class Map {
                 this.blpuPolygon.bringToFront();
               });
               //zoom to the bounds of the blpu polygon (different options depending on showLegend or not)
-              if (this.mapConfig.showLegend && (! isMobileFn())){
-                console.log('hi');
-                this.map.fitBounds(this.blpuPolygon.getBounds(), {
-                  animate: false,
-                  paddingTopLeft: [270, 0]
-                });
+              if (this.mapConfig.showLegend && (!isMobileFn())){
+                if (! this.isFullScreen){
+                  this.map.fitBounds(this.blpuPolygon.getBounds(), {
+                    animate: false,
+                    paddingTopLeft: [270, 0]
+                  });
+                }
+                else{
+                  this.map.fitBounds(this.blpuPolygon.getBounds(), {
+                    animate: false,
+                    paddingTopLeft: [400, 0]
+                  });
+                }
               }
               else{
                 this.map.fitBounds(this.blpuPolygon.getBounds(), {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -3,6 +3,7 @@ import L from "leaflet";
 import "proj4leaflet";
 import {getWFSurl, getWMSurl} from "../helpers/hackneyGeoserver";
 import {
+  isMobile,
   isMobile as isMobileFn,
   mobileDesktopSwitch
 } from "../helpers/isMobile";
@@ -132,12 +133,18 @@ class Map {
                 this.blpuPolygon.bringToFront();
               });
               //zoom to the bounds of the blpu polygon (different options depending on showLegend or not)
-              this.map.fitBounds(this.blpuPolygon.getBounds(), {
-                animate: false,
-                paddingTopLeft: [270, 0]
-              });
-
-               
+              if (this.mapConfig.showLegend && (! isMobileFn())){
+                console.log('hi');
+                this.map.fitBounds(this.blpuPolygon.getBounds(), {
+                  animate: false,
+                  paddingTopLeft: [270, 0]
+                });
+              }
+              else{
+                this.map.fitBounds(this.blpuPolygon.getBounds(), {
+                  animate: false
+                });
+              } 
             } else {
               this.popUpText = "PROPERTY LOCATION "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
             }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -10,6 +10,7 @@ import "leaflet-easybutton";
 import "leaflet-control-custom";
 import "leaflet-control-window";
 import "leaflet-search";
+import "leaflet-geometryutil";
 import { GestureHandling } from "leaflet-gesture-handling";
 import {
   MAX_ZOOM,
@@ -116,6 +117,8 @@ class Map {
         
             if (geometryType == "Polygon"){
               this.popUpText = "PROPERTY BOUNDARY "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
+              this.zoom = null;
+              console.log(this.zoom);
               this.blpuPolygon = new L.GeoJSON(data, {
                 color:"black",
                 weight: 3,
@@ -129,7 +132,23 @@ class Map {
                 console.log('overlayAdd');
                 this.blpuPolygon.bringToFront();
               });
-              //this.map.fitBounds(this.blpuPolygon.getBounds());
+              //zoom to the bounds of the blpu polygon
+              this.map.fitBounds(this.blpuPolygon.getBounds(),true);
+              //get boundsZoom in order to calculate the shift required to center the map on the polygon when there is a legend. 
+              let boundsZoom = this.map.getZoom();
+              console.log(boundsZoom);
+              if (boundsZoom == 11){
+                let currentCenter = this.map.getCenter();
+                let angleInDegrees = -90;
+                //let radiusInKm = 1;
+                let radiusInMeters = 0.4375 * 135; //pixel resolution * width of the legend in pixels
+                //let legendPixels = 270;
+                let newCenter =  L.GeometryUtil.destination(currentCenter, angleInDegrees, radiusInMeters);
+                console.log(currentCenter);
+                console.log(newCenter);
+                this.map.setView(newCenter);
+              }
+               
             } else {
               this.popUpText = "PROPERTY LOCATION "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
             }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -157,7 +157,7 @@ class Map {
               }),
               alt: 'address'
             })
-            .bindPopup(this.popUpText);
+            .bindPopup(this.popUpText, {maxWidth: 210});
             this.marker.addTo(this.map);
             this.marker.openPopup();
             

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -10,7 +10,6 @@ import "leaflet-easybutton";
 import "leaflet-control-custom";
 import "leaflet-control-window";
 import "leaflet-search";
-import "leaflet-geometryutil";
 import { GestureHandling } from "leaflet-gesture-handling";
 import {
   MAX_ZOOM,
@@ -132,22 +131,12 @@ class Map {
                 console.log('overlayAdd');
                 this.blpuPolygon.bringToFront();
               });
-              //zoom to the bounds of the blpu polygon
-              this.map.fitBounds(this.blpuPolygon.getBounds(),true);
-              //get boundsZoom in order to calculate the shift required to center the map on the polygon when there is a legend. 
-              let boundsZoom = this.map.getZoom();
-              console.log(boundsZoom);
-              if (boundsZoom == 11){
-                let currentCenter = this.map.getCenter();
-                let angleInDegrees = -90;
-                //let radiusInKm = 1;
-                let radiusInMeters = 0.4375 * 135; //pixel resolution * width of the legend in pixels
-                //let legendPixels = 270;
-                let newCenter =  L.GeometryUtil.destination(currentCenter, angleInDegrees, radiusInMeters);
-                console.log(currentCenter);
-                console.log(newCenter);
-                this.map.setView(newCenter);
-              }
+              //zoom to the bounds of the blpu polygon (different options depending on showLegend or not)
+              this.map.fitBounds(this.blpuPolygon.getBounds(), {
+                animate: false,
+                paddingTopLeft: [270, 0]
+              });
+
                
             } else {
               this.popUpText = "PROPERTY LOCATION "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -1,7 +1,5 @@
 
 import L from "leaflet";
-import ADDRESSES_PROXY_PROD from "../helpers/addressesProxy";
-// import {HACKNEY_GEOSERVER_EXTERNAL_WMS, HACKNEY_GEOSERVER_INTERNAL_WMS, HACKNEY_GEOSERVER_EXTERNAL_WFS, HACKNEY_GEOSERVER_INTERNAL_WFS} from "../helpers/hackneyGeoserver";
 import "proj4leaflet";
 import {getWFSurl, getWMSurl} from "../helpers/hackneyGeoserver";
 import {
@@ -28,7 +26,6 @@ import {
   GENERIC_OUTSIDE_HACKNEY_ERROR,
   TILE_LAYER_OPTIONS_OS,
   PERSONA_ACTIVE_CLASS,
-  //INTERNAL_HOSTNAME
 } from "./consts";
 import OS_RASTER_API_KEY  from "../helpers/osdata";
 import "@fortawesome/fontawesome-pro/js/all";
@@ -60,6 +57,7 @@ class Map {
     this.isFullScreen = false;
     this.uprn = null;
     this.marker = null;
+    this.blpuPolygon=null;
     this.geoserver_wfs_url = getWFSurl();
     this.geoserver_wms_url = getWMSurl();
   }
@@ -108,25 +106,36 @@ class Map {
             let singleLineAddress = data.features[0].properties.full_address_line;
             let usage = data.features[0].properties.usage_primary;
             let ward = data.features[0].properties.ward;
+            let geometryType = data.features[0].geometry.type;
 
             let latlon = [latitudeUPRN,longitudeUPRN];
             this.setViewFromLatlon(latlon);
             this.createMap();
         
-            this.popUpText = "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
-            this.marker = L.marker([latitudeUPRN,longitudeUPRN], {
-              icon: L.AwesomeMarkers.icon({
-                icon: 'fa-building',
-                prefix: "fa",
-                markerColor: 'red',
-                spin: false
-              }),
-              alt: 'address'
-            })
-            .bindPopup(this.popUpText);
-            this.marker.addTo(this.map);
-            this.marker.openPopup();
-            
+            if (geometryType == "Polygon"){
+              this.popUpText = "PROPERTY BOUNDARY "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
+              this.blpuPolygon = new L.GeoJSON(data, {
+                color:"red",
+                weight: 3,
+                opacity: 0.65
+              });      
+              this.blpuPolygon.addTo(this.map);
+              //this.map.fitBounds(this.blpuPolygon.getBounds());
+              } else {
+                this.popUpText = "PROPERTY LOCATION "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
+              }
+              this.marker = L.marker([latitudeUPRN,longitudeUPRN], {
+                icon: L.AwesomeMarkers.icon({
+                  icon: 'fa-building',
+                  prefix: "fa",
+                  markerColor: 'red',
+                  spin: false
+                }),
+                alt: 'address'
+              })
+              .bindPopup(this.popUpText);
+              this.marker.addTo(this.map);
+              this.marker.openPopup();
           })
           .catch(error => {
             console.log(error);

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -97,31 +97,23 @@ class Map {
 
         //If there is an uprn, we get the lat/long from the addresses API, add a marker and zoom to the area of interest
         if (this.uprn){
-          fetch(ADDRESSES_PROXY_PROD+"?format=detailed&uprn="+this.uprn, {
+          fetch(this.geoserver_wfs_url+"llpg:blpu_details_test&cql_filter=uprn="+this.uprn, {
             method: "get"
           })
           .then(response => response.json())
           .then(data => {
             //console.log (data);
-            let latitudeUPRN = data.data.data.address[0].latitude;
-            let longitudeUPRN = data.data.data.address[0].longitude;
-            let singleLineAddress = data.data.data.address[0].singleLineAddress;
-            let usage = data.data.data.address[0].usagePrimary;
-            let ward = data.data.data.address[0].ward;
+            let latitudeUPRN = data.features[0].properties.latitude;
+            let longitudeUPRN = data.features[0].properties.longitude;
+            let singleLineAddress = data.features[0].properties.full_address_line;
+            let usage = data.features[0].properties.usage_primary;
+            let ward = data.features[0].properties.ward;
 
-            //TODO Change the setView for replacing the center of the map when creating the map 
             let latlon = [latitudeUPRN,longitudeUPRN];
             this.setViewFromLatlon(latlon);
             this.createMap();
-            // if (this.mapConfig.showLegend) {
-            //   this.controls = new Controls(this);
-            //   this.controls.init();
-            // }
-            // new DataLayers(this).loadLayers();
-            // new Metadata(this).loadMetadata();
-
+        
             this.popUpText = "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
-            // this.map.setView([latitudeUPRN,longitudeUPRN], this.zoom);
             this.marker = L.marker([latitudeUPRN,longitudeUPRN], {
               icon: L.AwesomeMarkers.icon({
                 icon: 'fa-building',


### PR DESCRIPTION
# Description

When a UPRN is in the URL, use Geoserver instead of the Addresses API to locate it
When the retrieved record also has a BLPU polygon, load it onto the map and recentre it



## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
