### PR TITLE
Task/make zoom to mm optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,7 @@ The options for the data file are as follows:
 | `about` | String | optional | If `showGeoServerMetadata` is set to false, `about` can be used to populate the text in the infoBox described above. |
 | `aboutTitle` | String | optional | `aboutTitle` can be used to populate the title of the infoBox described above (e.g: About the data/About the map) |
 | `baseStyle` | String | optional | style to use for the base map. Possible values:<br>`OSlight`: OS Light style. <br>`OSoutdoor`: OS Outdoor style. <br>`OSroad`: OS Road style.<br>We removed the MapBox option in Sept 2021 and are now only using British National Grid as the map CRS.|
-| `zoomToMasterMap` | Boolean | optional | This is currently not is use and will be reimplemeted soon.|
-| `zoomToMasterMapBW` | Boolean | optional | If `true` the top 3 levels of zoom show Ordnance Survey masterMap black and white style. |
+| `blockZoomToMasterMap` | Boolean | optional | If `true` the map will block the zoom to the detailed view (OS MasterMap).|
 | `showLocateButton` | Boolean | optional | If `true` a button with geolocation function will be added to the map. |
 | `showFullScreenButton` | Boolean | optional | If `true` a button with fullscreen function will be added to the map. |
 | `showResetZoomButton` | Boolean | optional | If `true` a button resetting the zoom to show the full extent of Hackney will be added to the map. (Non mobile devices only) | 

--- a/data/air-quality-no2/map-definition.json
+++ b/data/air-quality-no2/map-definition.json
@@ -7,6 +7,7 @@
   "baseStyle": "OSoutdoor",
   "showHackneyMask": true,
   "showHackneyBoundary": true,
+  "blockZoomToMasterMap": true,
   "layers": [
     {
       "title": "22-25 (ug/m3)",

--- a/data/air-quality-pm10/map-definition.json
+++ b/data/air-quality-pm10/map-definition.json
@@ -7,6 +7,7 @@
   "baseStyle": "OSoutdoor",
   "showHackneyMask": true,
   "showHackneyBoundary": true,
+  "blockZoomToMasterMap": true,
   "layers": [
     {
       "title": "18 (ug/m3)",

--- a/data/air-quality-pm2-5/map-definition.json
+++ b/data/air-quality-pm2-5/map-definition.json
@@ -7,6 +7,7 @@
   "baseStyle": "OSoutdoor",
   "showHackneyMask": true,
   "showHackneyBoundary": true,
+  "blockZoomToMasterMap": true,
   "layers": [
     {
       "title": "12 (ug/m3)",

--- a/src/js/map/consts.js
+++ b/src/js/map/consts.js
@@ -1,8 +1,6 @@
 import MAPBOX_ACCESS_KEY from "../helpers/mapbox";
 import OS_RASTER_API_KEY from "../helpers/osdata";
 
-
-const MAX_ZOOM = 12;
 const MIN_ZOOM = 4;
 const CENTER_DESKTOP_LEGEND_FULLSCREEN = [51.534, -0.083];
 const CENTER_DESKTOP_LEGEND = [51.548, -0.083];
@@ -106,7 +104,6 @@ const CONTROLS_CLEAR_MAP_TEXT = "Clear map";
 const FILTER_INPUT_CLASS = "filters__input";
 
 export {
-  MAX_ZOOM,
   MIN_ZOOM,
   CENTER_DESKTOP_LEGEND_FULLSCREEN,
   CENTER_DESKTOP_LEGEND,

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -13,7 +13,6 @@ import "leaflet-control-window";
 import "leaflet-search";
 import { GestureHandling } from "leaflet-gesture-handling";
 import {
-  MAX_ZOOM,
   MIN_ZOOM,
   CENTER_DESKTOP_LEGEND,
   CENTER_DESKTOP_LEGEND_FULLSCREEN,
@@ -56,6 +55,7 @@ class Map {
     this.centerMobile = [];
     this.zoom =null;
     this.zoom_mobile=null;
+    this.maxZoom = null;
     this.isFullScreen = false;
     this.uprn = null;
     this.blpuMarker = null;
@@ -267,13 +267,20 @@ class Map {
       origin: [ -238375.0, 1376256.0 ]
     });
 
+    //set a max zoom if blockZoomToMasterMap is true to block the detailed view. By default, the max soom is 12 and zoom to MasterMap.
+     if (this.mapConfig.blockZoomToMasterMap){
+      this.maxZoom= 9;
+    } else {
+      this.maxZoom = 12;
+    }
+
     //gesture handler
     L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling);
 
     this.map = L.map("map", {
       crs: crs,
       zoomControl: false,
-      maxZoom: MAX_ZOOM,
+      maxZoom: this.maxZoom,
       minZoom: MIN_ZOOM,
       center: this.centerDesktop,
       zoom: this.zoom,

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -269,7 +269,7 @@ class Map {
 
     //set a max zoom if blockZoomToMasterMap is true to block the detailed view. By default, the max soom is 12 and zoom to MasterMap.
      if (this.mapConfig.blockZoomToMasterMap){
-      this.maxZoom= 9;
+      this.maxZoom = 9;
     } else {
       this.maxZoom = 12;
     }


### PR DESCRIPTION
# Description
 - The zoom to MasterMap has been made optional by using blockZoomToMasterMap

# How to test
The three new air quality maps use the blockZoomToMasterMap
Check any other map for the default behaviour



