### PR TITLE
add max-width to the title box

### DIFF
--- a/src/scss/partials/_metadata.scss
+++ b/src/scss/partials/_metadata.scss
@@ -35,7 +35,8 @@
 .metadata__title {
   //display: inline-block;
   float: right;
-  line-height: 1.3rem
+  line-height: 1.3rem;
+  max-width: 300px;
 }
 
 .metadata__link {


### PR DESCRIPTION
# Description

Max-width added to the title box. This will split the title in two lines when it is too long

Fixes # (issue)

## Type of change

- [ ] Improvement fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

# Checklist:

- [ ] I have checked a few random maps to check that the title was still ok. Also checked a few that had a long title (e.g: HC plan map)
