### PR TITLE
2 extra css classes for the legend to enable multi-line entries

### DIFF
--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -325,19 +325,19 @@ class DataLayers {
       const count = layer.getLayers().length;
 
       if (markerIcon2){
-            const legendEntry = `<span aria-hidden="true" class="control__active-border" style="background:${
+            const legendEntry = `<div class="legend-entry"><div><span aria-hidden="true" class="control__active-border" style="background:${
               MARKER_COLORS[markerColorIcon2]
-            }"></span><span class="fa-layers fa-fw"><i class="${markerIcon}" style="color:${MARKER_COLORS[markerColor]}"></i><i class="${markerIcon2}" data-fa-transform="shrink-2" style="color:${MARKER_COLORS[markerColorIcon2]}"></i></span><br><span class="control__text">${layerName}</br><span id="map-layer-count-${layer.getLayerId(
+            }"></span></div><div><span class="fa-layers fa-fw"><i class="${markerIcon}" style="color:${MARKER_COLORS[markerColor]}"></i><i class="${markerIcon2}" data-fa-transform="shrink-2" style="color:${MARKER_COLORS[markerColorIcon2]}"></i></span></div><div class="legend-entry-text"><span class="control__text">${layerName}</br><span id="map-layer-count-${layer.getLayerId(
               layer
-            )}" class="control__count">${count} items shown</span>`;
+            )}" class="control__count">${count} items shown</span></div></div>`;
             this.overlayMaps[legendEntry] = layer;
        
       } else {
-        const legendEntry = `<span aria-hidden="true" class="control__active-border" style="background:${
+        const legendEntry = `<div class="legend-entry"><div><span aria-hidden="true" class="control__active-border" style="background:${
           MARKER_COLORS[markerColor]
-        }"></span><span class="fa-layers fa-fw"><i class="${markerIcon}" style="color:${MARKER_COLORS[markerColor]}"></i></span><br><span class="control__text">${layerName}</br><span id="map-layer-count-${layer.getLayerId(
+        }"></span></div><div><span class="fa-layers fa-fw"><i class="${markerIcon}" style="color:${MARKER_COLORS[markerColor]}"></i></span></div><div class="legend-entry-text"><span class="control__text">${layerName}</br><span id="map-layer-count-${layer.getLayerId(
           layer
-        )}" class="control__count">${count} items shown</span>`;
+        )}" class="control__count">${count} items shown</span></div></div>`;
         this.overlayMaps[legendEntry] = layer;
 
       }

--- a/src/scss/partials/_controls.scss
+++ b/src/scss/partials/_controls.scss
@@ -197,7 +197,7 @@
 
 .control__text {
   @include lbh-rem(font-size, 14);
-  @include lbh-rem(padding-left, 10);
+  // @include lbh-rem(padding-left, 10);
   box-sizing: border-box;
   max-width: calc(100% - 32px);
   max-width: calc(100% - 2rem);
@@ -301,4 +301,13 @@ input:not(:checked) + span span.control__active-border {
 .fa-fw {
   text-align: center;
   width: 2.25em;
+}
+
+.legend-entry {
+  width: 100%;
+  display: flex;
+}
+
+.legend-entry-text {
+  @include lbh-rem(padding-left, 10);
 }


### PR DESCRIPTION
# Description

Reorganise legend entries with a flex div (in addition to the existing spans) so that  multi-line entries look tidy

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code

