### PR TITLE
Feature/pick the boundary and mask layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,9 @@ The options for the data file are as follows:
 | `showFullScreenButton` | Boolean | optional | If `true` a button with fullscreen function will be added to the map. |
 | `showResetZoomButton` | Boolean | optional | If `true` a button resetting the zoom to show the full extent of Hackney will be added to the map. (Non mobile devices only) | 
 | `showMask` | Boolean | optional | If `true` a semi-opaque Hackney white mask will be added to all areas that fall outside of Hackney. Hackney mask is the default mask. If `true` and a maskGeoserverName is added, the mask displayed will be the custom one instead.|
-| `maskGeoserverName` | String | optional | If the maskGeoserverName is not empty and showMask is `true`, the semi-opaque white mask will be the custom one instead of Hakcney mask.|
-| `showHackneyBoundary` | Boolean | optional | If `true` the Hackney boundary will be added to the map |
+| `maskGeoserverName` | String | optional | If the maskGeoserverName is not empty and showMask is `true`, the semi-opaque white mask will be the custom one instead of Hackney mask.|
+| `showBoundary` | Boolean | optional | If `true` the Hackney boundary will be added to the map. The Hackney boundary is the default boundary. If `true` and a boundaryGeoserverName is added, the boundary displayed will be the custom one instead.| 
+| `boundaryGeoserverName` | String | optional | If the boundaryGeoserverName is not empty and showBoundary is `true`, the custom boundary will be added instead.|
 | `showLegend` | Boolean | optional | If `true` a legend will show on the map. |
 | `performDrillDown` | Boolean | optional | If `true` a combined/drill down popUp window will be switched on. If `false`, the single default popUp window will be used instead. The default value is `false`. |
 | `hideNumberOfItems` | Boolean | optional | If `true` The number of items is hidden on the legend. If `false`, the number of items is shown on the layer. The default value is `false`. |

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The options for the data file are as follows:
 | `showLocateButton` | Boolean | optional | If `true` a button with geolocation function will be added to the map. |
 | `showFullScreenButton` | Boolean | optional | If `true` a button with fullscreen function will be added to the map. |
 | `showResetZoomButton` | Boolean | optional | If `true` a button resetting the zoom to show the full extent of Hackney will be added to the map. (Non mobile devices only) | 
-| `showMask` | Boolean | optional | If `true` a semi-opaque Hackney white mask will be added to all areas that fall outside of Hackney. Hackney mask is the default mask. | If `true` and a [maskGeoserverName](#maskGeoserverName)is added, the mask displayed will be the custom one instead.|
-| `maskGeoserverName` | String | optional | If the maskGeoserverName is not empty and [showMask](#showMask) is `true`, the semi-opaque white mask will be the custom one instead of Hakcney mask.|
+| `showMask` | Boolean | optional | If `true` a semi-opaque Hackney white mask will be added to all areas that fall outside of Hackney. Hackney mask is the default mask. If `true` and a maskGeoserverName is added, the mask displayed will be the custom one instead.|
+| `maskGeoserverName` | String | optional | If the maskGeoserverName is not empty and showMask is `true`, the semi-opaque white mask will be the custom one instead of Hakcney mask.|
 | `showHackneyBoundary` | Boolean | optional | If `true` the Hackney boundary will be added to the map |
 | `showLegend` | Boolean | optional | If `true` a legend will show on the map. |
 | `performDrillDown` | Boolean | optional | If `true` a combined/drill down popUp window will be switched on. If `false`, the single default popUp window will be used instead. The default value is `false`. |

--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ The options for the data file are as follows:
 | `showLocateButton` | Boolean | optional | If `true` a button with geolocation function will be added to the map. |
 | `showFullScreenButton` | Boolean | optional | If `true` a button with fullscreen function will be added to the map. |
 | `showResetZoomButton` | Boolean | optional | If `true` a button resetting the zoom to show the full extent of Hackney will be added to the map. (Non mobile devices only) | 
-| `showHackneyMask` | Boolean | optional | If `true` a semi-opaque white mask will be added to all areas that fall outside of Hackney. |
+| `showMask` | Boolean | optional | If `true` a semi-opaque Hackney white mask will be added to all areas that fall outside of Hackney. Hackney mask is the default mask. | If `true` and a [maskGeoserverName](#maskGeoserverName)is added, the mask displayed will be the custom one instead.|
+| `maskGeoserverName` | String | optional | If the maskGeoserverName is not empty and [showMask](#showMask) is `true`, the semi-opaque white mask will be the custom one instead of Hakcney mask.|
 | `showHackneyBoundary` | Boolean | optional | If `true` the Hackney boundary will be added to the map |
 | `showLegend` | Boolean | optional | If `true` a legend will show on the map. |
 | `performDrillDown` | Boolean | optional | If `true` a combined/drill down popUp window will be switched on. If `false`, the single default popUp window will be used instead. The default value is `false`. |

--- a/data/boundaries-test/map-definition.json
+++ b/data/boundaries-test/map-definition.json
@@ -1,0 +1,9 @@
+{
+  "title": "Hackney wards",
+  "baseStyle": "OSoutdoor",
+  "showMask": true, 
+  "maskGeoserverName":"boundaries:city_hackney_mask",
+  "showBoundary": true,
+  "boundaryGeoserverName":"health:health_care_neighbourhood",
+  "layers": []
+}

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -104,7 +104,6 @@ class Map {
           })
           .then(response => response.json())
           .then(data => {
-            //console.log (data);
             let latitudeUPRN = data.features[0].properties.latitude;
             let longitudeUPRN = data.features[0].properties.longitude;
             let singleLineAddress = data.features[0].properties.full_address_line;
@@ -121,7 +120,6 @@ class Map {
             if (geometryType == "Polygon"){
               this.popUpText = "PROPERTY BOUNDARY "+"<br>" + "ADDRESS: " + singleLineAddress + "<br>" + "UPRN: " + this.uprn+"<br>" + "PRIMARY USAGE: " + usage.toUpperCase() +"<br>" + "WARD: " + ward.toUpperCase() +"<br>" ;
               this.zoom = null;
-              //console.log(this.zoom);
               this.blpuPolygon = new L.GeoJSON(data, {
                 color:"black",
                 weight: 3,
@@ -132,7 +130,6 @@ class Map {
               this.blpuPolygon.bringToFront();
               //always keep this layer on top 
               this.map.on("overlayadd", (event) => {
-                console.log('overlayAdd');
                 this.blpuPolygon.bringToFront();
               });
               //zoom to the bounds of the blpu polygon (different options depending on showLegend or not)
@@ -193,7 +190,6 @@ class Map {
             this.blpuMarker.openPopup(); 
           })
           .catch(error => {
-            console.log(error);
             this.error.innerHTML = "There was a problem retrieving the UPRN. Please try again.";
           });
         }
@@ -223,7 +219,6 @@ class Map {
        
       })
       .catch(error => {
-        console.log(error);
       });
   }
 
@@ -350,9 +345,7 @@ class Map {
         this.boundaryGeoserverName = this.mapConfig.boundaryGeoserverName;
       } else {
         this.boundaryGeoserverName = "boundaries:hackney";
-        console.log("inside show boundary - else scenario" + this.boundaryGeoserverName);
       }
-    console.log(this.boundaryGeoserverName);
       this.addBoundaryLayer(this.boundaryGeoserverName);
     }
     

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -332,20 +332,20 @@ class Map {
     this.addBaseLayer();
 
     if (this.mapConfig.showMask) {
-      if (this.mapConfig.maskGeoserverName){
-        this.maskGeoserverName = this.mapConfig.maskGeoserverName;
-      } else {
-        this.maskGeoserverName = "boundaries:hackney_mask";
-      }
-    this.addMaskLayer(this.maskGeoserverName);
+        if (this.mapConfig.maskGeoserverName){
+          this.maskGeoserverName = this.mapConfig.maskGeoserverName;
+        } else {
+          this.maskGeoserverName = "boundaries:hackney_mask";
+        }
+      this.addMaskLayer(this.maskGeoserverName);
     }
 
     if (this.mapConfig.showBoundary) {
-      if (this.mapConfig.boundaryGeoserverName){
-        this.boundaryGeoserverName = this.mapConfig.boundaryGeoserverName;
-      } else {
-        this.boundaryGeoserverName = "boundaries:hackney";
-      }
+        if (this.mapConfig.boundaryGeoserverName){
+          this.boundaryGeoserverName = this.mapConfig.boundaryGeoserverName;
+        } else {
+          this.boundaryGeoserverName = "boundaries:hackney";
+        }
       this.addBoundaryLayer(this.boundaryGeoserverName);
     }
     

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -43,7 +43,8 @@ class Map {
     this.container = map.parentElement.parentElement;
     this.dataFolder = null;
     this.mapConfig = null;
-    this.hackneyMask = null;
+    this.mask = null;
+    this.maskGeoserverName = null;
     this.hackneyBoundary = null;
     this.mapBase = null;
     this.hasPersonas = false;
@@ -334,8 +335,16 @@ class Map {
     
     this.addBaseLayer();
 
-    if (this.mapConfig.showHackneyMask) {
-      this.addHackneyMaskLayer();
+    if (this.mapConfig.showMask) {
+      console.log("inside show mask");
+      if (this.mapConfig.maskGeoserverName){
+        this.maskGeoserverName = this.mapConfig.maskGeoserverName;
+      } else {
+        this.maskGeoserverName = "boundaries:hackney_mask";
+        console.log("inside show mask - else scenario" + this.maskGeoserverName);
+      }
+    console.log(this.maskGeoserverName);
+    this.addMaskLayer(this.maskGeoserverName);
     }
 
     if (this.mapConfig.showHackneyBoundary) {
@@ -375,14 +384,14 @@ class Map {
     this.map.addLayer(this.mapBase);
   }
   
-  addHackneyMaskLayer() {
-    this.hackneyMask = L.tileLayer.wms(this.geoserver_wms_url, {
-      layers: "boundaries:hackney_mask",
+  addMaskLayer(maskLayerName) {
+    this.mask = L.tileLayer.wms(this.geoserver_wms_url, {
+      layers: maskLayerName,
       transparent: true,
       tiled: true,
       format: "image/png"
     });
-    this.map.addLayer(this.hackneyMask);
+    this.map.addLayer(this.mask);
   }
 
   addHackneyBoundaryLayer() {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -383,6 +383,7 @@ class Map {
   }
   
   addMaskLayer(maskLayerName) {
+    //The mask style is defined in Geoserver
     this.mask = L.tileLayer.wms(this.geoserver_wms_url, {
       layers: maskLayerName,
       transparent: true,
@@ -393,6 +394,7 @@ class Map {
   }
 
   addBoundaryLayer(boundaryLayerName) {
+    //The boundary style is defined in Geoserver
     this.boundary = L.tileLayer.wms(this.geoserver_wms_url, {
       layers: boundaryLayerName,
       transparent: true,

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -45,7 +45,8 @@ class Map {
     this.mapConfig = null;
     this.mask = null;
     this.maskGeoserverName = null;
-    this.hackneyBoundary = null;
+    this.boundary = null;
+    this.boundaryGeoserverName = null;
     this.mapBase = null;
     this.hasPersonas = false;
     this.errorOutsideHackney = GENERIC_OUTSIDE_HACKNEY_ERROR;
@@ -336,19 +337,23 @@ class Map {
     this.addBaseLayer();
 
     if (this.mapConfig.showMask) {
-      console.log("inside show mask");
       if (this.mapConfig.maskGeoserverName){
         this.maskGeoserverName = this.mapConfig.maskGeoserverName;
       } else {
         this.maskGeoserverName = "boundaries:hackney_mask";
-        console.log("inside show mask - else scenario" + this.maskGeoserverName);
       }
-    console.log(this.maskGeoserverName);
     this.addMaskLayer(this.maskGeoserverName);
     }
 
-    if (this.mapConfig.showHackneyBoundary) {
-      this.addHackneyBoundaryLayer();
+    if (this.mapConfig.showBoundary) {
+      if (this.mapConfig.boundaryGeoserverName){
+        this.boundaryGeoserverName = this.mapConfig.boundaryGeoserverName;
+      } else {
+        this.boundaryGeoserverName = "boundaries:hackney";
+        console.log("inside show boundary - else scenario" + this.boundaryGeoserverName);
+      }
+    console.log(this.boundaryGeoserverName);
+      this.addBoundaryLayer(this.boundaryGeoserverName);
     }
     
     //Load the layers
@@ -394,14 +399,14 @@ class Map {
     this.map.addLayer(this.mask);
   }
 
-  addHackneyBoundaryLayer() {
-    this.hackneyBoundary = L.tileLayer.wms(this.geoserver_wms_url, {
-      layers: "boundaries:hackney",
+  addBoundaryLayer(boundaryLayerName) {
+    this.boundary = L.tileLayer.wms(this.geoserver_wms_url, {
+      layers: boundaryLayerName,
       transparent: true,
       tiled: true,
       format: "image/png"
     });
-    this.map.addLayer(this.hackneyBoundary);
+    this.map.addLayer(this.boundary);
   }
 
   setZoom() {


### PR DESCRIPTION
# Description

- Rename the showHackneyMask and showHackneyBoundary tags. 
-  Allow the option of choosing a custom mask and boundary instead of the Hackney one. 


## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've tested the map not showing the mask and boundary, showing the default ones and choosing the ones I prefer. 
The map called boundaries-test can be used for testing.

# Checklist:

- [ ] I have performed a self-review of my own code and tested the existing maps
