### PR TITLE
block the minZoom map level

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The options for the data file are as follows:
 | `aboutTitle` | String | optional | `aboutTitle` can be used to populate the title of the infoBox described above (e.g: About the data/About the map) |
 | `baseStyle` | String | optional | style to use for the base map. Possible values:<br>`OSlight`: OS Light style. <br>`OSoutdoor`: OS Outdoor style. <br>`OSroad`: OS Road style.<br>We removed the MapBox option in Sept 2021 and are now only using British National Grid as the map CRS.|
 | `blockZoomToMasterMap` | Boolean | optional | If `true` the map will block the zoom to the detailed view (OS MasterMap).|
+| `minMapZoom` | Number | optional | It allows you to specify what is the min map zoom level.The map will block the zoom when zooming out beyond that level.|
 | `showLocateButton` | Boolean | optional | If `true` a button with geolocation function will be added to the map. |
 | `showFullScreenButton` | Boolean | optional | If `true` a button with fullscreen function will be added to the map. |
 | `showResetZoomButton` | Boolean | optional | If `true` a button resetting the zoom to show the full extent of Hackney will be added to the map. (Non mobile devices only) | 

--- a/data/health-neighbourhood-clissold-park/map-definition.json
+++ b/data/health-neighbourhood-clissold-park/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_cp_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/data/health-neighbourhood-hackney-downs/map-definition.json
+++ b/data/health-neighbourhood-hackney-downs/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_hd_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/data/health-neighbourhood-hackney-marshes/map-definition.json
+++ b/data/health-neighbourhood-hackney-marshes/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_hm_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/data/health-neighbourhood-london-fields/map-definition.json
+++ b/data/health-neighbourhood-london-fields/map-definition.json
@@ -9,6 +9,7 @@
     "showMask": true,
     "maskGeoserverName": "health:health_care_neighbourhood_lf_mask",
     "baseStyle": "OSlight",
+    "minMapZoom":7,
     "layers": [
       {
         "title": "GP surgeries",

--- a/data/health-neighbourhood-shoreditch-and-city/map-definition.json
+++ b/data/health-neighbourhood-shoreditch-and-city/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_sc_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/data/health-neighbourhood-springfield-park/map-definition.json
+++ b/data/health-neighbourhood-springfield-park/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_sp_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/data/health-neighbourhood-well-street/map-definition.json
+++ b/data/health-neighbourhood-well-street/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_ws_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/data/health-neighbourhood-woodberry-wetlands/map-definition.json
+++ b/data/health-neighbourhood-woodberry-wetlands/map-definition.json
@@ -9,6 +9,7 @@
   "maskGeoserverName": "health:health_care_neighbourhood_ww_mask",
   "showFirstLayerOnLoad": true,
   "baseStyle": "OSlight",
+  "minMapZoom":7,
   "layers": [
     {
       "title": "GP surgeries",

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -13,6 +13,7 @@ import "leaflet-control-window";
 import "leaflet-search";
 import { GestureHandling } from "leaflet-gesture-handling";
 import {
+  MIN_ZOOM,
   CENTER_DESKTOP_LEGEND,
   CENTER_DESKTOP_LEGEND_FULLSCREEN,
   CENTER_DESKTOP_NO_LEGEND,
@@ -286,7 +287,7 @@ class Map {
      if (this.mapConfig.minMapZoom){
       this.minZoom = this.mapConfig.minMapZoom;
     } else {
-      this.minZoom = 4;
+      this.minZoom = MIN_ZOOM;
     }
 
     //gesture handler

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -13,7 +13,6 @@ import "leaflet-control-window";
 import "leaflet-search";
 import { GestureHandling } from "leaflet-gesture-handling";
 import {
-  MIN_ZOOM,
   CENTER_DESKTOP_LEGEND,
   CENTER_DESKTOP_LEGEND_FULLSCREEN,
   CENTER_DESKTOP_NO_LEGEND,
@@ -58,6 +57,7 @@ class Map {
     this.zoom =null;
     this.zoom_mobile=null;
     this.maxZoom = null;
+    this.minZoom = null;
     this.isFullScreen = false;
     this.uprn = null;
     this.blpuMarker = null;
@@ -282,6 +282,13 @@ class Map {
       this.maxZoom = 12;
     }
 
+     //set a max zoom if blockZoomToMasterMap is true to block the detailed view. By default, the max soom is 12 and zoom to MasterMap.
+     if (this.mapConfig.minMapZoom){
+      this.minZoom = this.mapConfig.minMapZoom;
+    } else {
+      this.minZoom = 4;
+    }
+
     //gesture handler
     L.Map.addInitHook("addHandler", "gestureHandling", GestureHandling);
 
@@ -289,7 +296,7 @@ class Map {
       crs: crs,
       zoomControl: false,
       maxZoom: this.maxZoom,
-      minZoom: MIN_ZOOM,
+      minZoom: this.minZoom,
       center: this.centerDesktop,
       zoom: this.zoom,
       gestureHandling: L.Browser.mobile


### PR DESCRIPTION
# Description

Block the min Zoom level of the map if minMapZoom is added to the config

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've checked the maps with and without the functionality. Work as expected. 
One of the health neighbourhood maps can be used to test the functionality

# Checklist:
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation


