### PR TITLE
Improvement/customise address search popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Object properties:
 | `notFoundText` | String | required | Message appearing under the search box if no result is found. |
 | `clearMapAfterSearch` | Boolean | required | If true, the map is cleared before displaying the retrieved object(s), so only the result is shown. If false, the result is highlighted but all other objects will remain on the map. |
 | `closePopUpWindow` | Boolean | optional |  If true, the popUp window of the selected address is closed by default.|
-| `addressSearchIcon` | String | optional | FontAwesome icon name of the address search marker | If it is not specified, the default icon is displayed.|
+| `addressSearchIcon` | String | optional | FontAwesome icon name of the address search marker. If it is not specified, the default icon is displayed.|
 
 
 ### Layer Options

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Object properties:
 | `searchPlaceholderText` | String | required | Hint text displayed in grey inside the search bar. Example: 'type postcode or block name'. |
 | `notFoundText` | String | required | Message appearing under the search box if no result is found. |
 | `clearMapAfterSearch` | Boolean | required | If true, the map is cleared before displaying the retrieved object(s), so only the result is shown. If false, the result is highlighted but all other objects will remain on the map. |
+| `closePopUpWindow` | Boolean | optional |  If true, the popUp window of the selected address is closed by default.|
+| `addressSearchIcon` | String | optional | FontAwesome icon name of the address search marker | If it is not specified, the default icon is displayed.|
 
 
 ### Layer Options

--- a/data/car-clubs-v2-draft/map-definition.json
+++ b/data/car-clubs-v2-draft/map-definition.json
@@ -19,6 +19,7 @@
   "showLocateButton":true,
   "showAddressSearch": {
     "addressSearchExpanded": "closed",
+    "addressSearchIcon": "fa-map-pin",
     "closePopUpWindow": true
   },
   "filtersSectionTitle":"Filters",

--- a/data/car-clubs-v2-draft/map-definition.json
+++ b/data/car-clubs-v2-draft/map-definition.json
@@ -18,7 +18,8 @@
   "showBoundary": true,
   "showLocateButton":true,
   "showAddressSearch": {
-    "addressSearchExpanded": "closed"
+    "addressSearchExpanded": "closed",
+    "closePopUpWindow": true
   },
   "filtersSectionTitle":"Filters",
   "filters": {

--- a/src/js/map/address-search.js
+++ b/src/js/map/address-search.js
@@ -293,7 +293,9 @@ class addressSearch {
       })
     .bindPopup(this.popUpText, {maxWidth: 210});
     this.marker.addTo(this.map);
-    this.marker.openPopup();   
+    if (!this.mapConfig.showAddressSearch.closePopUpWindow){
+      this.marker.openPopup();  
+    }
   }
 }
 export default addressSearch;

--- a/src/js/map/address-search.js
+++ b/src/js/map/address-search.js
@@ -12,6 +12,7 @@ class addressSearch {
     this.mapClass = mapClass;
     this.map = mapClass.map;
     this.mapConfig = mapClass.mapConfig;
+    this.addressSearchIcon = null;
     this.showAddressSearch = null;
     this.searchButton = null;
     this.postcodeBox = null;
@@ -49,6 +50,7 @@ class addressSearch {
     this.addressSearchLabel = this.showAddressSearch.addressSearchLabel || 'Go to an address';
     this.addressSearchExpanded = this.showAddressSearch.addressSearchExpanded || 'open';
     this.addressSearchClue = this.showAddressSearch.addressSearchClue || 'Enter a Hackney postcode or address';
+    this.addressSearchIcon = this.showAddressSearch.addressSearchIcon || 'fa-home-alt';
     
     this.createMarkup();
     this.bindSearchButton();
@@ -280,11 +282,10 @@ class addressSearch {
       this.mapClass.blpuPolygon = null;
     }
     
-
     //Create the marker, add the pop up and add the layer to the map
     this.marker = L.marker([this.selectedLat, this.selectedLong], {
         icon: L.AwesomeMarkers.icon({
-          icon: 'fa-home-alt',
+          icon: this.addressSearchIcon,
           prefix: "fa",
           markerColor: 'black',
           spin: false


### PR DESCRIPTION
# Description

- Added an option to keep the popUp windows closed by default in the Address search.
- Customised the FontAwesome icon for the Address search. If it is not specified, the default one is used. 

## Type of change

- [ ] Breaking change (an improvement that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

