### PR TITLE
only use 2 fontawesome styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/polyfill": "^7.8.7",
-    "@fortawesome/fontawesome-pro": "^6.0.0",
+    "@fortawesome/fontawesome-pro": "^6.1.1",
     "@turf/boolean-point-in-polygon": "^6.5.0",
     "@turf/turf": "^6.5.0",
     "classlist-polyfill": "^1.2.0",

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -28,7 +28,9 @@ import {
   PERSONA_ACTIVE_CLASS,
 } from "./consts";
 import OS_RASTER_API_KEY  from "../helpers/osdata";
-import "@fortawesome/fontawesome-pro/js/all";
+import "@fortawesome/fontawesome-pro/js/solid";
+import "@fortawesome/fontawesome-pro/js/regular";
+import "@fortawesome/fontawesome-pro/js/fontawesome";
 import Geolocation from "./geolocation";
 import Controls from "./controls";
 import DataLayers from "./data-layers";


### PR DESCRIPTION
# Description

Stop using fontawesome/all and uses only 2 styles instead.

Fixes # (issue)
javascript file was 16Mb since the move to v6, it is now back to 6Mb

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Opened all maps locally and checked if icons were loading correctly

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
