### PR TITLE
Customise cluster zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Object properties:
 | `markerColor` | String | optional | Colour of the marker when `markerType` is set to `"AwesomeMarker"` or `"CircleMarker"`. See variable `MARKER_COLORS` in `src/js/map/consts.js` to get the list of colours. |
 | `markerIcon2` | String | optional | Colour of the second marker when there is a second icon `icon2` is required. See variable `MARKER_COLORS` in `src/js/map/consts.js` to get the list of colours. |
 | `cluster` | Boolean | optional | If `true`, Leaflet will use the ClusterMarker plugin up to zoom 17. Beyond zoom 17 the individual markers will be used as defined above. We use a purple cluster style with a level of transparency depending on the size of the cluster. |
-| `disableClusteringAtZoom` | Number | optional | This value is the zoom level at what the clustering will be disabled. It can only be used if the cluster is `true`. If the cluster is `true` and the zoom is empty, the clustering will be disabled at the zoom level 12.|
+| `disableClusteringAtZoom` | Number | optional | This value is the zoom level at which the clustering will be disabled. It can only be used if the cluster is `true`. If the cluster is `true` and the zoom is empty, the clustering will be disabled at the zoom level 12.|
 
 ### Line Polygon Options
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Object properties:
 | `markerColor` | String | optional | Colour of the marker when `markerType` is set to `"AwesomeMarker"` or `"CircleMarker"`. See variable `MARKER_COLORS` in `src/js/map/consts.js` to get the list of colours. |
 | `markerIcon2` | String | optional | Colour of the second marker when there is a second icon `icon2` is required. See variable `MARKER_COLORS` in `src/js/map/consts.js` to get the list of colours. |
 | `cluster` | Boolean | optional | If `true`, Leaflet will use the ClusterMarker plugin up to zoom 17. Beyond zoom 17 the individual markers will be used as defined above. We use a purple cluster style with a level of transparency depending on the size of the cluster. |
+| `disableClusteringAtZoom` | Number | optional | This value is the zoom level at what the clustering will be disabled. It can only be used if the cluster is `true`. If the cluster is `true` and the zoom is empty, the clustering will be disabled at the zoom level 12.|
 
 ### Line Polygon Options
 

--- a/data/flood-assets-register/map-definition.json
+++ b/data/flood-assets-register/map-definition.json
@@ -28,6 +28,29 @@
       }
     },  
     {
+      "title": "Gullies",
+        "sortOrder":2,
+        "geoserverLayerName": "pollution:gully",
+        "pointStyle": {
+          "markerType": "CircleMarker",
+          "circleMarkerRadius": 5,
+          "icon": "fas fa-circle",
+          "markerColor": "jacarta",
+          "cluster": true, 
+          "disableClusteringAtZoom": 9
+        },
+        "linePolygonStyle": {
+          "styleName": "default",
+          "stroke": true,
+          "strokeColor": "#522b6c",
+          "opacity": 1,
+          "fillColor": "#522b6c",
+          "fillOpacity": 1,
+          "layerLineDash": "",
+          "weight": 1
+        }
+      },
+    {
       "title": "Flood structures",
       "geoserverLayerName": "flood:hackney_flood_structure",
       "sortOrder":6,

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -167,6 +167,8 @@ class DataLayers {
     const markerColor = pointStyle && pointStyle.markerColor;
     const markerColorIcon2 = pointStyle && pointStyle.markerColorIcon2;
     const cluster = pointStyle && pointStyle.cluster;
+    const disableClusteringAtZoom = pointStyle && pointStyle.disableClusteringAtZoom ? pointStyle && pointStyle.disableClusteringAtZoom : 12;
+
     var clusterLayer = null;
 
     const linePolygonStyle = configLayer.linePolygonStyle;
@@ -292,7 +294,7 @@ class DataLayers {
       //create clusters layer
       clusterLayer = L.markerClusterGroup({
         maxClusterRadius: 60,
-        disableClusteringAtZoom: 12,
+        disableClusteringAtZoom: disableClusteringAtZoom,
         spiderfyOnMaxZoom: false,
         showCoverageOnHover: false
       });


### PR DESCRIPTION
# Description

Customise the zoom level at which the clustering will be disabled. 

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Flood Assets map tested with and without disableClusteringAtZoom

