### PR TITLE
open popup closest to map centre

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Object properties:
 | `highlightFeatureOnHover` | Boolean | optional | If true, polygon features will be highlighted on mouse hover. |
 | `zoomToFeatureOnClick` | Boolean | optional | If true, clicking on a polygon features will zoom to its extent. |
 | `followLinkOnClick` | String | optional | Set to the name of the field containing a hyperlink. If set, clicking on a feature will follow the link. Links starting with http open in a blank tab, others are just moving to different sections of the page.|
+| `openPopupClosestToMapCentre` | Boolean | optional | If true, the feature closest to the map center will have its popup open on load. Use if you're planning to use coordinates in the URL. If the closest feature is in a markerCluster, its popup won't open.|
 | `pointStyle` | Object | optional | Configures marker style in point layers. Leave empty if the layer is not a point layer. [See Point Style Options for details](#point-style-options) |
 | `linePolygonStyle` | Object | optional | Used to configure style for lines or polygons. Leave empty if the layer is a point layer. [See Line Polygon Options for details](#line-polygon-options) |
 | `popup` | Object | optional | Used to configure the popups for the layer. [See Popup Options for details](#popup-options) |

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "leaflet-control-custom": "^1.0.0",
     "leaflet-control-window": "^1.0.0",
     "leaflet-easybutton": "^2.4.0",
+    "leaflet-geometryutil": "^0.10.1",
     "leaflet-gesture-handling": "^1.1.8",
     "leaflet-panel-layers": "^1.2.6",
     "leaflet-search": "^2.9.8",

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -331,6 +331,11 @@ class DataLayers {
        }
       }    
     }
+    //open popup closest to the map centre
+    if (configLayer.openPopupClosestToMapCentre){
+      let closestMarker = L.GeometryUtil.closestLayer(this.map, layer.getLayers(), this.map.getCenter());
+      closestMarker.layer.openPopup();
+    }
 
     this.loadedLayerCount++;
 

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -11,6 +11,7 @@ import "leaflet-easybutton";
 import "leaflet-control-custom";
 import "leaflet-control-window";
 import "leaflet-search";
+import "leaflet-geometryutil";
 import { GestureHandling } from "leaflet-gesture-handling";
 import {
   MIN_ZOOM,


### PR DESCRIPTION
# Description

A new flag in the map config enables to open the pop-up of the feature the closest to the map centre.


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [ X] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ X] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
