### PR TITLE
Improve the order of modules above the map

### DIFF
--- a/src/js/map/address-search.js
+++ b/src/js/map/address-search.js
@@ -46,6 +46,7 @@ class addressSearch {
   }
     
   init() {
+    console.log ('init address search');
     this.showAddressSearch = this.mapConfig.showAddressSearch;
     this.addressSearchLabel = this.showAddressSearch.addressSearchLabel || 'Go to an address';
     this.addressSearchExpanded = this.showAddressSearch.addressSearchExpanded || 'open';
@@ -123,8 +124,8 @@ class addressSearch {
     </div>
     </details>
       </section>`;
-
-    this.mapClass.addMarkupToMap(html, "addressSearch", "addresSsearch"); 
+    console.log('adding address search markup to map');
+    this.mapClass.addMarkupToTop(html, "addressSearch", "addresSsearch"); 
     this.searchButton = document.getElementById("search-button");
     this.postcodeBox = document.getElementById("postcode");
   }

--- a/src/js/map/controls.js
+++ b/src/js/map/controls.js
@@ -69,7 +69,7 @@ class Controls {
         </sidebar>
       </div>
     `;
-    this.mapClass.addMarkupToMap(html, "controls", "controls");
+    this.mapClass.addMarkupToTop(html, "controls", "controls");
   }
 
   createMarkupFullScreen() {
@@ -103,7 +103,7 @@ class Controls {
         </sidebar>
       </div>    
     `;
-    this.mapClass.addMarkupToMap(html, "controls", "controls");
+    this.mapClass.addMarkupToTop(html, "controls", "controls");
   }
 
 

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -506,8 +506,14 @@ class DataLayers {
       
       //only happens once, after the last layer has loaded
       if (this.loadedLayerCount == this.layerCount){
+        console.log('after last layer: create markup for layer search')
         this.search.createMarkup();
       }     
+    }
+    //only happens once, after the last layer has loaded: address search
+    if (this.loadedLayerCount == this.layerCount && this.mapConfig.showAddressSearch){
+      this.showAddressSearch = new addressSearch(this.mapClass);
+      this.showAddressSearch.init();
     }
   }
 
@@ -561,15 +567,13 @@ class DataLayers {
       }
     }
     if (this.mapConfig.search){
-      //this.searchLayer = new L.LayerGroup([]);
       this.search = new Search(this.mapClass);
       this.search.init();
-    }if (this.mapConfig.showAddressSearch){
-      //this.searchLayer = new L.LayerGroup([]);
-      this.showAddressSearch = new addressSearch(this.mapClass);
-      this.showAddressSearch.init();
-      //this.showAddressSearch.createMarkup();
     }
+    // if (this.mapConfig.showAddressSearch){
+    //   this.showAddressSearch = new addressSearch(this.mapClass);
+    //   this.showAddressSearch.init();
+    // }
 
     //for each layer in the config file
     for (const configLayer of this.mapConfig.layers) {

--- a/src/js/map/filters.js
+++ b/src/js/map/filters.js
@@ -16,6 +16,7 @@ class Filters {
   }
 
   init() {
+    console.log ('init filters');
     this.filters = this.mapConfig.filtersSection.filters;
     this.filtersSectionTitle = this.mapConfig.filtersSection.filtersSectionTitle || 'Filter';
     this.filtersSectionState = this.mapConfig.filtersSection.filtersSectionState || 'closed';
@@ -63,7 +64,8 @@ class Filters {
       </fieldset>`;
     }
     html += `</div></div></details><button id="filters-clear" class="govuk-button lbh-button filters__clear">Clear filters</button></section>`;
-    this.mapClass.addMarkupToMap(html, "filters", "filters");
+    console.log('adding filter markup to map');
+    this.mapClass.addMarkupJustAboveMap(html, "filters", "filters");
     this.clearButton = document.getElementById("filters-clear");
   }
 

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -399,7 +399,7 @@ class Map {
       this.addBoundaryLayer(this.boundaryGeoserverName);
     }
     
-    //Add the layers from cofig
+    //Add the layers from config
     if(this.mapConfig.layers[0].vectorTilesLayer){
       new VectorTileDataLayers(this).loadLayers();
     } 
@@ -531,12 +531,21 @@ class Map {
 
   }
 
-  addMarkupToMap(markup, id, className) {
+  addMarkupToTop(markup, id, className) {
     const element = document.createElement("section");
     element.setAttribute("id", id);
     element.classList.add(className);
     element.innerHTML = markup;
+    console.log(this.container);
     this.container.insertBefore(element, this.container.firstChild);
+  }
+
+  addMarkupJustAboveMap(markup, id, className) {
+    const element = document.createElement("section");
+    element.setAttribute("id", id);
+    element.classList.add(className);
+    element.innerHTML = markup;
+    this.container.insertBefore(element, document.getElementById("controls"));
   }
 
   addMarkupToMapAfter(markup, id, className) {

--- a/src/js/map/search.js
+++ b/src/js/map/search.js
@@ -8,6 +8,7 @@ class Search {
     }
     
     init() {
+      console.log('init layer search');
       this.search = this.mapConfig.search;
       //this.createMarkup();
       this.searchLayer = new L.LayerGroup([]); 
@@ -25,8 +26,9 @@ class Search {
   </div>
   </details>
     </section>`;
-
-    this.mapClass.addMarkupToMap(html, "search", "search");
+    
+    console.log('adding search markup to map');
+    this.mapClass.addMarkupToTop(html, "search", "search");
         
       //extension of search plugin that does NOT add the searched layer to the map
       const HackneyLeafletSearch = L.Control.Search.extend({


### PR DESCRIPTION
# Description

Improve the order of modules above the map: first 'Go to address', then 'Search', then 'Filter'

Fixes # (issue)
Non-intuitive order

## Type of change

Please delete options that are not relevant.

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
