### PR TITLE
Update data-layers.js

### DIFF
--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -275,11 +275,13 @@ class DataLayers {
       });
     }
 
-    if (highlightFeatureOnHoverOrSelect) {
+    if (highlightFeatureOnHoverOrSelect && linePolygonStyle) {
       layer.on("mouseover", event => {
-        event.propagatedFrom.setStyle({
-          weight: weight + 2
-        });
+        if (event.propagatedFrom instanceof L.Polygon || event.propagatedFrom instanceof L.Polyline) {
+          event.propagatedFrom.setStyle({
+            weight: weight + 2
+          });
+        }
       });
 
       layer.on("mouseout", event => {


### PR DESCRIPTION
Prevent highlightFeatureOnClick for point layers

# Description

Bug fix

Fixes # pop ups freezing on point layers having hihlightFeatureOnClickOrSelect=true

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
