### PR TITLE
Run spatial enrichements after load to prepare for Summary table 

### DIFF
--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -8,6 +8,7 @@ import Search from "./search";
 import addressSearch from "./address-search";
 import List from "./list-view";
 import DrillDown from "./drill-down";
+import SpatialEnrichment from "./spatial-enrichment";
 
 
 class DataLayers {
@@ -29,6 +30,7 @@ class DataLayers {
     this.search = null;
     this.showAddressSearch = null;
     this.list = null;
+    this.spatialEnrichmentFlag = false;
   }
 
   pointToLayer (latlng, configLayer) {
@@ -415,7 +417,10 @@ class DataLayers {
       let closestMarker = L.GeometryUtil.closestLayer(this.map, layer.getLayers(), this.map.getCenter());
       closestMarker.layer.openPopup();
     }
-
+    //if there are some spatial enrichments for this layer, set the flag to true
+    if (configLayer.spatialEnrichments){
+      this.spatialEnrichmentFlag = true;
+    }
     this.loadedLayerCount++;
 
     //only happens once, after the last layer has loaded - put the BLPUpolygon layer on top if it exists
@@ -439,6 +444,12 @@ class DataLayers {
     if (this.mapConfig.performDrillDown && this.loadedLayerCount == this.layerCount) {
         this.drilldown = new DrillDown(this.map);
         this.drilldown.init();
+    }
+
+    //Spatial enrichment and replace 'data' with the enriched feature collection.
+    if (this.spatialEnrichmentFlag && this.loadedLayerCount == this.layerCount) {
+      this.spatialenrichment = new SpatialEnrichment(this.mapClass, this.layersData);
+      this.spatialenrichment.init();
     }
       
     if (this.mapConfig.showLegend) {

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -8,7 +8,6 @@ import Search from "./search";
 import addressSearch from "./address-search";
 import List from "./list-view";
 import DrillDown from "./drill-down";
-import SpatialEnrichment from "./spatial-enrichment";
 
 
 class DataLayers {
@@ -419,26 +418,11 @@ class DataLayers {
     
     this.loadedLayerCount++;
 
-    //only happens once, after the last layer has loadedSpatial enrichment and replace 'data' with the enriched feature collection.
-    if (this.mapClass.spatialEnrichments && this.loadedLayerCount == this.layerCount) {
-      this.mapClass.spatialEnrichments.enrichLayers(this.layersData);
-    }
+
 
     //only happens once, after the last layer has loaded - put the BLPUpolygon layer on top if it exists
     if (this.mapClass.blpuPolygon && this.loadedLayerCount == this.layerCount) {
       this.mapClass.blpuPolygon.bringToFront();
-    }
-
-    //only happens once, after the last layer has loaded - create filters above the map
-    if (this.mapConfig.filtersSection && this.loadedLayerCount == this.layerCount) {
-      this.filters = new Filters(this.mapClass, this.layersData);
-      this.filters.init();
-    }
-
-    //only happens once, after the last layer has loaded - create list view after the map
-    if (this.mapConfig.list && this.loadedLayerCount == this.layerCount) {
-      this.list = new List(this.mapClass,this.layersData);
-      this.list.init();
     }
 
     //only happens once, after the last layer has loaded - add the drill down listener if true
@@ -537,6 +521,25 @@ class DataLayers {
         this.search.createMarkup();
       }     
     }
+
+    
+    //only happens once, after the last layer has loaded: spatial enrichment
+    if (this.mapClass.spatialEnrichments && this.loadedLayerCount == this.layerCount) {
+      this.mapClass.spatialEnrichments.enrichLayers(this.layersData);
+    }
+    
+    //only happens once, after the last layer has loaded - create filters above the map
+    if (this.mapConfig.filtersSection && this.loadedLayerCount == this.layerCount) {
+      this.filters = new Filters(this.mapClass, this.layersData);
+      this.filters.init();
+    }
+
+    //only happens once, after the last layer has loaded - create list view after the map
+    if (this.mapConfig.list && this.loadedLayerCount == this.layerCount) {
+      this.list = new List(this.mapClass,this.layersData);
+      this.list.init();
+    }
+
     //only happens once, after the last layer has loaded: address search
     if (this.loadedLayerCount == this.layerCount && this.mapConfig.showAddressSearch){
       this.showAddressSearch = new addressSearch(this.mapClass);

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -30,7 +30,6 @@ class DataLayers {
     this.search = null;
     this.showAddressSearch = null;
     this.list = null;
-    this.spatialEnrichmentFlag = false;
   }
 
   pointToLayer (latlng, configLayer) {
@@ -417,11 +416,13 @@ class DataLayers {
       let closestMarker = L.GeometryUtil.closestLayer(this.map, layer.getLayers(), this.map.getCenter());
       closestMarker.layer.openPopup();
     }
-    //if there are some spatial enrichments for this layer, set the flag to true
-    if (configLayer.spatialEnrichments){
-      this.spatialEnrichmentFlag = true;
-    }
+    
     this.loadedLayerCount++;
+
+    //only happens once, after the last layer has loadedSpatial enrichment and replace 'data' with the enriched feature collection.
+    if (this.mapClass.spatialEnrichments && this.loadedLayerCount == this.layerCount) {
+      this.mapClass.spatialEnrichments.enrichLayers(this.layersData);
+    }
 
     //only happens once, after the last layer has loaded - put the BLPUpolygon layer on top if it exists
     if (this.mapClass.blpuPolygon && this.loadedLayerCount == this.layerCount) {
@@ -446,11 +447,7 @@ class DataLayers {
         this.drilldown.init();
     }
 
-    //Spatial enrichment and replace 'data' with the enriched feature collection.
-    if (this.spatialEnrichmentFlag && this.loadedLayerCount == this.layerCount) {
-      this.spatialenrichment = new SpatialEnrichment(this.mapClass, this.layersData);
-      this.spatialenrichment.init();
-    }
+
       
     if (this.mapConfig.showLegend) {
       if (!configLayer.excludeFromLegend){

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -525,12 +525,8 @@ class DataLayers {
     //only happens once, after the last layer has loaded: spatial enrichment
     if (this.mapClass.spatialEnrichments && this.loadedLayerCount == this.layerCount) {
       this.mapClass.spatialEnrichments.enrichLayers(this.layersData);
-      console.log('this is the new layersData post enrich: ');
-      console.log(this.layersData);
     }
     
-    
-
     //only happens once, after the last layer has loaded - create filters above the map
     if (this.mapConfig.filtersSection && this.loadedLayerCount == this.layerCount) {
       this.filters = new Filters(this.mapClass, this.layersData);

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -521,13 +521,16 @@ class DataLayers {
         this.search.createMarkup();
       }     
     }
-
-    
+   
     //only happens once, after the last layer has loaded: spatial enrichment
     if (this.mapClass.spatialEnrichments && this.loadedLayerCount == this.layerCount) {
       this.mapClass.spatialEnrichments.enrichLayers(this.layersData);
+      console.log('this is the new layersData post enrich: ');
+      console.log(this.layersData);
     }
     
+    
+
     //only happens once, after the last layer has loaded - create filters above the map
     if (this.mapConfig.filtersSection && this.loadedLayerCount == this.layerCount) {
       this.filters = new Filters(this.mapClass, this.layersData);
@@ -609,23 +612,23 @@ class DataLayers {
     for (const configLayer of this.mapConfig.layers) {
       //Get the right geoserver WFS link using the hostname
       let url = '';
-            //If there is cql, we add the cql filter to the wfs call
-            if (configLayer.cqlFilter){
-              url = this.mapClass.geoserver_wfs_url + configLayer.geoserverLayerName + "&cql_filter=" + configLayer.cqlFilter;
-            //If not, we use the default wfs call
-            } else{
-              url = this.mapClass.geoserver_wfs_url + configLayer.geoserverLayerName;
-            }
-          //Fetch the url
-          fetch(url, {
-            method: "get"
-          })
-            .then(response => response.json())
-            .then(data => this.addWFSLayer(data, configLayer))
-            .catch(error => {
-              console.log(error);
-              alert("Something went wrong, please reload the page");
-            });     
+      //If there is cql, we add the cql filter to the wfs call
+      if (configLayer.cqlFilter){
+        url = this.mapClass.geoserver_wfs_url + configLayer.geoserverLayerName + "&cql_filter=" + configLayer.cqlFilter;
+      //If not, we use the default wfs call
+      } else{
+        url = this.mapClass.geoserver_wfs_url + configLayer.geoserverLayerName;
+      }
+      //Fetch the url
+      fetch(url, {
+        method: "get"
+      })
+      .then(response => response.json())
+      .then(data => this.addWFSLayer(data, configLayer))
+      .catch(error => {
+        console.log(error);
+        alert("Something went wrong, please reload the page");
+      });     
     }
   }
 }

--- a/src/js/map/list-view.js
+++ b/src/js/map/list-view.js
@@ -49,27 +49,28 @@ class List {
             </h5>
           </div>`;
         }
-        
-        for (var feat of layerData.layer.getLayers()){
+        console.log('layerData.data.features');
+        console.log(layerData.data.features)
+        for (const feature of layerData.data.features){
           //for (var feature of layerData.data.features){
           // html += `<div id="default-example-content-1" class="govuk-accordion__section-content" aria-labelledby="default-example-heading-1">
           // <ul class="lbh-list lbh-list--bullet">
           // <li>${feature.properties.organisation_name}</li>
           // </ul></div>`;
           html += `<div id="default-example-content-1" class="govuk-accordion__section-content">
-          <h6>${feat.feature.properties[layerData.configLayer.listView.title]}</h6>`;
+          <h6>${feature.properties[layerData.configLayer.listView.title]}</h6>`;
           if (layerData.configLayer.listView.fields) {
             html += `<p class="lbh-body-s">`;
             for (const field of layerData.configLayer.listView.fields) {
-              if (feat.feature.properties[field] !== "") {
+              if (feature.properties[field] !== "") {
                 if (
-                  feat.feature.properties[field.name] !== "" &&
-                  feat.feature.properties[field.name] !== null
+                  feature.properties[field.name] !== "" &&
+                  feature.properties[field.name] !== null
                 ) {
                   if (field.label != "") {
-                    html += `${field.label}</span>: ${feat.feature.properties[field.name]}<br>`;
+                    html += `${field.label}</span>: ${feature.properties[field.name]}<br>`;
                   } else {
-                    html += `${feat.feature.properties[field.name]}<br>`;
+                    html += `${feature.properties[field.name]}<br>`;
                   }
                 }     
               }

--- a/src/js/map/list-view.js
+++ b/src/js/map/list-view.js
@@ -49,14 +49,7 @@ class List {
             </h5>
           </div>`;
         }
-        console.log('layerData.data.features');
-        console.log(layerData.data.features)
         for (const feature of layerData.data.features){
-          //for (var feature of layerData.data.features){
-          // html += `<div id="default-example-content-1" class="govuk-accordion__section-content" aria-labelledby="default-example-heading-1">
-          // <ul class="lbh-list lbh-list--bullet">
-          // <li>${feature.properties.organisation_name}</li>
-          // </ul></div>`;
           html += `<div id="default-example-content-1" class="govuk-accordion__section-content">
           <h6>${feature.properties[layerData.configLayer.listView.title]}</h6>`;
           if (layerData.configLayer.listView.fields) {

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -403,7 +403,7 @@ class Map {
       this.addBoundaryLayer(this.boundaryGeoserverName);
     }
     //prepare flag for spatial enrichments if necessary
-    if (this.mapConfig.spatialEnrichments) {
+    if (this.mapConfig.spatialEnrichmentRequired) {
       this.spatialEnrichments = new SpatialEnrichment(this);
       //this.spatialEnrichments.loadGeographyLayers();
     }

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -402,10 +402,10 @@ class Map {
         }
       this.addBoundaryLayer(this.boundaryGeoserverName);
     }
-    //prepare layers for spatial enrichment if necessary
+    //prepare flag for spatial enrichments if necessary
     if (this.mapConfig.spatialEnrichments) {
       this.spatialEnrichments = new SpatialEnrichment(this);
-      this.spatialEnrichments.loadGeographyLayers();
+      //this.spatialEnrichments.loadGeographyLayers();
     }
     //Add the layers from config
     if (this.mapConfig.layers[0].vectorTilesLayer){

--- a/src/js/map/map.js
+++ b/src/js/map/map.js
@@ -38,6 +38,7 @@ import DataLayers from "./data-layers";
 import VectorTileDataLayers from "./vector-tile-data-layers";
 import Metadata from "./metadata";
 import "classlist-polyfill";
+import SpatialEnrichment from "./spatial-enrichment";
 
 class Map {
   constructor(map) {
@@ -401,9 +402,13 @@ class Map {
         }
       this.addBoundaryLayer(this.boundaryGeoserverName);
     }
-    
+    //prepare layers for spatial enrichment if necessary
+    if (this.mapConfig.spatialEnrichments) {
+      this.spatialEnrichments = new SpatialEnrichment(this);
+      this.spatialEnrichments.loadGeographyLayers();
+    }
     //Add the layers from config
-    if(this.mapConfig.layers[0].vectorTilesLayer){
+    if (this.mapConfig.layers[0].vectorTilesLayer){
       new VectorTileDataLayers(this).loadLayers();
     } 
     else {

--- a/src/js/map/spatial-enrichment.js
+++ b/src/js/map/spatial-enrichment.js
@@ -14,7 +14,7 @@ class SpatialEnrichment {
       if (enrichedLayer.configLayer.spatialEnrichments){
         console.log('Enriching '+enrichedLayer.configLayer.title+', assuming it is a point layer');
         for (const spatialEnrichment of enrichedLayer.configLayer.spatialEnrichments){
-          //look for the corresponding geography layer (already loaded)
+          //look for the corresponding enriching layer (already loaded)
           for (const enrichingLayer of layersData){
             if (enrichingLayer.configLayer.title == spatialEnrichment.geographyLayer) {
               console.log('Enriching with '+enrichingLayer.configLayer.title+', assuming it is an area layer');
@@ -24,8 +24,6 @@ class SpatialEnrichment {
         }
       }
     }     
-    console.log('after all enrichments: ');
-    console.log(layersData);
   }
 }
 

--- a/src/js/map/spatial-enrichment.js
+++ b/src/js/map/spatial-enrichment.js
@@ -8,11 +8,9 @@ class SpatialEnrichment {
     this.geographyLayerDict = {};
   }
 
-  init(){
-    
-  }
+  init(){}
 
-  loadGeographyLayers(){
+  enrichLayers(layersData) {
     //list all geography layers to load
     let listGeographyLayerNames = [];
     for (const configLayer of this.mapConfig.layers){
@@ -38,7 +36,22 @@ class SpatialEnrichment {
           // console.log(layersData);
           this.geographyLayerDict[geographyLayerName] = data;
           if (Object.keys(this.geographyLayerDict).length == listGeographyLayerNames.length){
-            // console.log('Load completed for ' +listGeographyLayerNames.length+ ' geography layers');
+            console.log('Load completed for ' +listGeographyLayerNames.length+ ' geography layers');
+            //Now use TURF to do spatial joins between map layers and geography layers 
+            for (const layerData of layersData){
+              if (layerData.configLayer.spatialEnrichments){
+                for (const spatialEnrichment of layerData.configLayer.spatialEnrichments){
+                  // console.log('Enriching, assuming the layer to enrich is a point layer');
+                  // console.log('layersData:');
+                  // console.log(layerData.data);
+                  // console.log('laygeography layer: ');
+                  // console.log(this.geographyLayerDict[spatialEnrichment.geographyLayer]);
+                  layerData.data = turf.tag(layerData.data, this.geographyLayerDict[spatialEnrichment.geographyLayer], spatialEnrichment.sourceAttribute, spatialEnrichment.targetAttribute);  
+                }
+                // console.log('after enrichment: ');
+                // console.log(layersData);
+              }
+            }     
           }
         })
       .catch(error => {
@@ -46,22 +59,6 @@ class SpatialEnrichment {
         alert("Something went wrong while loading geography layers for spatial enrichment");
       });     
     }
-  }
-  
-  //Use TURF to do spatial joins between map layers and geography layers 
-  enrichLayers(layersData){ 
-    var enriched_data;
-    for (const layerData of layersData){
-      if (layerData.configLayer.spatialEnrichments){
-        for (const spatialEnrichment of layerData.configLayer.spatialEnrichments){
-          console.log('Enriching, assuming the layer to enrich is a point layer');
-          enriched_data = turf.tag(layerData.data, this.geographyLayerDict[spatialEnrichment.geographyLayer], spatialEnrichment.sourceAttribute, spatialEnrichment.targetAttribute);  
-          layerData.data = enriched_data;
-        }
-        console.log('after enrichment: ');
-        console.log(layersData);
-      }
-    }     
   }
 }
 

--- a/src/js/map/spatial-enrichment.js
+++ b/src/js/map/spatial-enrichment.js
@@ -4,61 +4,28 @@ import * as turf from '@turf/turf';
 class SpatialEnrichment {
   constructor(mapClass) {
     this.mapClass = mapClass;
-    this.mapConfig = mapClass.mapConfig;
-    this.geographyLayerDict = {};
   }
 
   init(){}
 
   enrichLayers(layersData) {
-    //list all geography layers to load
-    let listGeographyLayerNames = [];
-    for (const configLayer of this.mapConfig.layers){
-      if (configLayer.spatialEnrichments){
-        for (const spatialEnrichment of configLayer.spatialEnrichments){
-          if (! listGeographyLayerNames.includes(spatialEnrichment.geographyLayer)){
-            listGeographyLayerNames.push(spatialEnrichment.geographyLayer);
+    //use TURF to do spatial joins between map layers and geography layers 
+    for (const enrichedLayer of layersData){
+      if (enrichedLayer.configLayer.spatialEnrichments){
+        console.log('Enriching '+enrichedLayer.configLayer.title+', assuming it is a point layer');
+        for (const spatialEnrichment of enrichedLayer.configLayer.spatialEnrichments){
+          //look for the corresponding geography layer (already loaded)
+          for (const enrichingLayer of layersData){
+            if (enrichingLayer.configLayer.title == spatialEnrichment.geographyLayer) {
+              console.log('Enriching with '+enrichingLayer.configLayer.title+', assuming it is an area layer');
+              enrichedLayer.data = turf.tag(enrichedLayer.data, enrichingLayer.data, spatialEnrichment.sourceAttribute, spatialEnrichment.targetAttribute);  
+            }
           }
         }
       }
-    }
-    
-    //load each layer and keep count
-    let url = '';
-    for (const geographyLayerName of listGeographyLayerNames){
-      url = this.mapClass.geoserver_wfs_url + geographyLayerName;
-      //Fetch the url
-      fetch(url, {
-        method: "get"
-      })
-        .then(response => response.json())
-        .then(data => {
-          // console.log(layersData);
-          this.geographyLayerDict[geographyLayerName] = data;
-          if (Object.keys(this.geographyLayerDict).length == listGeographyLayerNames.length){
-            console.log('Load completed for ' +listGeographyLayerNames.length+ ' geography layers');
-            //Now use TURF to do spatial joins between map layers and geography layers 
-            for (const layerData of layersData){
-              if (layerData.configLayer.spatialEnrichments){
-                for (const spatialEnrichment of layerData.configLayer.spatialEnrichments){
-                  // console.log('Enriching, assuming the layer to enrich is a point layer');
-                  // console.log('layersData:');
-                  // console.log(layerData.data);
-                  // console.log('laygeography layer: ');
-                  // console.log(this.geographyLayerDict[spatialEnrichment.geographyLayer]);
-                  layerData.data = turf.tag(layerData.data, this.geographyLayerDict[spatialEnrichment.geographyLayer], spatialEnrichment.sourceAttribute, spatialEnrichment.targetAttribute);  
-                }
-                // console.log('after enrichment: ');
-                // console.log(layersData);
-              }
-            }     
-          }
-        })
-      .catch(error => {
-        console.log(error);
-        alert("Something went wrong while loading geography layers for spatial enrichment");
-      });     
-    }
+    }     
+    console.log('after all enrichments: ');
+    console.log(layersData);
   }
 }
 

--- a/src/js/map/spatial-enrichment.js
+++ b/src/js/map/spatial-enrichment.js
@@ -1,0 +1,71 @@
+import L from "leaflet";
+import * as turf from '@turf/turf';
+
+class SpatialEnrichment {
+  constructor(mapClass, layersData) {
+    this.mapClass = mapClass;
+    this.layersData = layersData;
+  }
+
+  init(){
+    this.loadGeographies(this.layersData);
+  }
+
+  loadGeographies(layersData){
+    //list all geography layers to load
+    let listGeographyLayerNames = [];
+    for (const layerData of layersData){
+      if (layerData.configLayer.spatialEnrichments){
+        for (const spatialEnrichment of layerData.configLayer.spatialEnrichments){
+          if (! listGeographyLayerNames.includes(spatialEnrichment.geographyLayer)){
+            listGeographyLayerNames.push(spatialEnrichment.geographyLayer);
+          }
+        }
+      }
+    }
+    
+    //load each layer and keep count
+    let geographyLayerDict = {};
+    let url = '';
+    for (const geographyLayerName of listGeographyLayerNames){
+      url = this.mapClass.geoserver_wfs_url + geographyLayerName;
+      //Fetch the url
+      fetch(url, {
+        method: "get"
+      })
+        .then(response => response.json())
+        .then(data => {
+          // console.log(layersData);
+          geographyLayerDict[geographyLayerName] = data;
+          if (Object.keys(geographyLayerDict).length == listGeographyLayerNames.length){
+            // console.log('Load completed for ' +listGeographyLayerNames.length+ ' geography layers');
+            this.enrichLayers(layersData, geographyLayerDict);
+          }
+        })
+      .catch(error => {
+        console.log(error);
+        alert("Something went wrong while loading geography layers for spatial enrichment");
+      });     
+
+    }
+
+  }
+  
+  //Use TURF to do spatial joins between map layers and geography layers 
+  enrichLayers(layersData, geographyLayerDict){ 
+    var enriched_data;
+    for (const layerData of layersData){
+      if (layerData.configLayer.spatialEnrichments){
+        for (const spatialEnrichment of layerData.configLayer.spatialEnrichments){
+          console.log('Enriching, assuming the layer to enrich is a point layer');
+          enriched_data = turf.tag(layerData.data, geographyLayerDict[spatialEnrichment.geographyLayer], spatialEnrichment.sourceAttribute, spatialEnrichment.targetAttribute);  
+          layerData.data = enriched_data;
+        }
+        // console.log('after enrichment: ');
+        // console.log(layersData);
+      }
+    }     
+  }
+}
+
+export default SpatialEnrichment;


### PR DESCRIPTION
# Description

Attempt to do spatial enrichment to prep for summary tables. Uses TURF. Only works for points on area for now. You can test this with the Bike-pumps external map. READ-ME hasn't been updated yet.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ X] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
