### PR TITLE
create search markup even if last layer is not searchable

### DIFF
--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -522,13 +522,14 @@ class DataLayers {
       // this.search = new Search(this.mapClass, layer);
       // this.search.init();
       this.search.searchLayer.addLayer(layer);
-      
-      //only happens once, after the last layer has loaded
-      if (this.loadedLayerCount == this.layerCount){
-        console.log('after last layer: create markup for layer search')
-        this.search.createMarkup();
-      }     
-    }
+    }  
+    
+    //only happens once, after the last layer has loaded
+    if (this.loadedLayerCount == this.layerCount && this.mapConfig.search){
+      console.log('after last layer: create markup for layer search')
+      this.search.createMarkup();
+    }     
+    
     //only happens once, after the last layer has loaded: address search
     if (this.loadedLayerCount == this.layerCount && this.mapConfig.showAddressSearch){
       this.showAddressSearch = new addressSearch(this.mapClass);

--- a/src/js/map/data-layers.js
+++ b/src/js/map/data-layers.js
@@ -526,7 +526,6 @@ class DataLayers {
     
     //only happens once, after the last layer has loaded
     if (this.loadedLayerCount == this.layerCount && this.mapConfig.search){
-      console.log('after last layer: create markup for layer search')
       this.search.createMarkup();
     }     
     

--- a/src/js/map/search.js
+++ b/src/js/map/search.js
@@ -29,7 +29,6 @@ class Search {
   </details>
     </section>`;
     
-    console.log('adding search markup to map');
     this.mapClass.addMarkupToTop(html, "search", "search");
         
       //extension of search plugin that does NOT add the searched layer to the map


### PR DESCRIPTION
# Description

Please include a summary of the change. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
Wrongly nested test: If the last layer that finishes loading is not searchable, the search ,mark up is not created. 

## Type of change

Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Locally

# Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my own code
- [ X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
